### PR TITLE
Readme install instructions update

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -27,7 +27,7 @@ Using the **devtools** package:
 devtools::install_github("kbenoit/sophistication")
 ```
 
-If you have a trouble with your **sophistication** installation using **devtools**, check that you have pre-installed **conda** or **mini-conda** and are using the correct version of **spacyr**. Try installing **sophistication** with the following steps:
+If you have trouble with your **sophistication** installation using **devtools**, check that you have pre-installed **conda** or **miniconda** and are using the correct version of **spacyr**. Try installing **sophistication** with the following steps:
 
 ``` {r, eval = FALSE}
 devtools::install_github("quanteda/spacyr", build_vignettes = FALSE)

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,8 +26,18 @@ Using the **devtools** package:
 ```{r, eval = FALSE}
 devtools::install_github("kbenoit/sophistication")
 ```
-                              
 
+If you have a trouble with your **sophistication** installation using **devtools**, check that you have pre-installed **conda** or **mini-conda** and are using the correct version of **spacyr**. Try installing **sophistication** with the following steps:
+
+``` {r, eval = FALSE}
+devtools::install_github("quanteda/spacyr", build_vignettes = FALSE)
+library("spacyr")
+spacy_install()
+spacy_initialize()
+devtools::install_github("kbenoit/sophistication")
+```
+
+For more information please see the **spacyr** documentation here: https://cran.r-project.org/web/packages/spacyr/readme/README.html .                              
 ### Included Data
 
 new name | original name | description

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Using the **devtools** package:
 devtools::install_github("kbenoit/sophistication")
 ```
 
+If you have a trouble with your **sophistication** installation using **devtools**, check that you have pre-installed **conda** or **mini-conda** and are using the correct version of **spacyr**. Try installing **sophistication** with the following steps:
+
+``` r
+devtools::install_github("quanteda/spacyr", build_vignettes = FALSE)
+library("spacyr")
+spacy_install()
+spacy_initialize()
+devtools::install_github("kbenoit/sophistication")
+```
+
+For more information please see the **spacyr** documentation here: https://cran.r-project.org/web/packages/spacyr/readme/README.html .
+
 ### Included Data
 
 | new name                     | original name      | description                           |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Using the **devtools** package:
 devtools::install_github("kbenoit/sophistication")
 ```
 
-If you have a trouble with your **sophistication** installation using **devtools**, check that you have pre-installed **conda** or **mini-conda** and are using the correct version of **spacyr**. Try installing **sophistication** with the following steps:
+If you have trouble with your **sophistication** installation using **devtools**, check that you have pre-installed **conda** or **miniconda** and are using the correct version of **spacyr**. Try installing **sophistication** with the following steps:
 
 ``` r
 devtools::install_github("quanteda/spacyr", build_vignettes = FALSE)


### PR DESCRIPTION
Updated the `README.Rmd` and `README.md` with the following edits to reflect the additional installation instructions we discussed in issue #11 :

______________________________________________________________________________________________________________________________

If you have trouble with your **sophistication** installation using **devtools**, check that you have pre-installed **conda** or **miniconda** and are using the correct version of **spacyr**. Try installing sophistication with the following steps:

```
devtools::install_github("quanteda/spacyr", build_vignettes = FALSE)
library("spacyr")
spacy_install()
spacy_initialize()
devtools::install_github("kbenoit/sophistication")
```

For more information please see the **spacyr** documentation here: https://cran.r-project.org/web/packages/spacyr/readme/README.html .

______________________________________________________________________________________________________________________________